### PR TITLE
Fix dihedrals and add executable for checking a match with the MDA backend

### DIFF
--- a/libdistopia/CMakeLists.txt
+++ b/libdistopia/CMakeLists.txt
@@ -34,3 +34,10 @@ target_sources(test PRIVATE "test/test.cpp")
 target_link_libraries(test PUBLIC gtest gtest_main)
 target_link_libraries(test PUBLIC distopia)
 target_include_directories(test PUBLIC  ${CMAKE_SOURCE_DIR})
+
+
+add_executable(test_mda_match)
+target_sources(test_mda_match PRIVATE "test/test_mda_match.cpp")
+target_link_libraries(test_mda_match PUBLIC gtest gtest_main)
+target_link_libraries(test_mda_match PUBLIC distopia)
+target_include_directories(test_mda_match PUBLIC  ${CMAKE_SOURCE_DIR})

--- a/libdistopia/src/distopia.cpp
+++ b/libdistopia/src/distopia.cpp
@@ -281,16 +281,6 @@ namespace distopia {
                 hn::LoadInterleaved3(d, b_src + 3 * p, b_x, b_y, b_z);
 
                 auto result = Distance(a_x, a_y, a_z, b_x, b_y, b_z, box);
-                #ifndef DEBUG_DIST
-                hn::Print(d, "ax is: ", a_x, 0, nlanes);
-                hn::Print(d, "ay is: ", a_y, 0, nlanes);
-                hn::Print(d, "az is: ", a_z, 0, nlanes);
-                std::cout << std::endl;
-                hn::Print(d, "bx is: ", b_x, 0, nlanes);
-                hn::Print(d, "by is: ", b_y, 0, nlanes);
-                hn::Print(d, "bz is: ", b_z, 0, nlanes);
-                hn::Print(d, "result is: ", result, 0, 16);
-                #endif
 
                 hn::StoreU(result, d, dst + p);
             }
@@ -444,6 +434,7 @@ namespace distopia {
                     rbc_x, rbc_y, rbc_z,
                     n1x, n1y, n1z);
 
+
             auto n2x = hn::Undefined(d);
             auto n2y = hn::Undefined(d);
             auto n2z = hn::Undefined(d);
@@ -460,24 +451,27 @@ namespace distopia {
                     n2x, n2y, n2z,
                     xp_x, xp_y, xp_z);
 
+
             auto x = hn::Zero(d);
-            hn::MulAdd(n1x, n2x, x);
-            hn::MulAdd(n1y, n2y, x);
-            hn::MulAdd(n1z, n2z, x);
+            x = hn::MulAdd(n1x, n2x, x);
+            x = hn::MulAdd(n1y, n2y, x);
+            x = hn::MulAdd(n1z, n2z, x);
 
             auto vb_norm = hn::Zero(d);
-            hn::MulAdd(bx, bx, vb_norm);
-            hn::MulAdd(by, by, vb_norm);
-            hn::MulAdd(bz, bz, vb_norm);
+            vb_norm = hn::MulAdd(rbc_x, rbc_x, vb_norm);
+            vb_norm = hn::MulAdd(rbc_y, rbc_y, vb_norm);
+            vb_norm = hn::MulAdd(rbc_z, rbc_z, vb_norm);
             vb_norm = hn::Sqrt(vb_norm);
 
             auto y = hn::Zero(d);
-            hn::MulAdd(xp_x, bx, y);
-            hn::MulAdd(xp_y, by, y);
-            hn::MulAdd(xp_z, bz, y);
+            y = hn::MulAdd(xp_x, rbc_x, y);
+            y = hn::MulAdd(xp_y, rbc_y, y);
+            y = hn::MulAdd(xp_z, rbc_z, y);
+            
             y = y / vb_norm;
 
-            return hn::Atan2(d, y, x);
+            // negate due to vector order (?)
+            return   hn::Neg(hn::Atan2(d, y, x));
         }
 
         template <typename T, typename B>
@@ -535,6 +529,8 @@ namespace distopia {
                 hn::LoadInterleaved3(d, b_src + 3 * p, b_x, b_y, b_z);
                 hn::LoadInterleaved3(d, c_src + 3 * p, c_x, c_y, c_z);
                 hn::LoadInterleaved3(d, d_src + 3 * p, d_x, d_y, d_z);
+
+
 
                 auto result = Dihedral(
                         a_x, a_y, a_z,

--- a/libdistopia/test/bench.cpp
+++ b/libdistopia/test/bench.cpp
@@ -5,150 +5,223 @@
 #include "distopia.h"
 #include "test_utils.h"
 #include "test_fixtures.h"
+#include <benchmark/benchmark.h>
+#include <iostream>
+#include <random>
+
+#include "distopia.h"
 
 
-constexpr int BOXSIZE = 30;
+#define BOXSIZE 30
 
-template <typename T>
-class CoordinatesBenchContainer : public benchmark::Fixture {
+
+template <typename T> class CoordinatesBench : public benchmark::Fixture {
 public:
   void SetUp(benchmark::State &state) override {
     ncoords = static_cast<std::size_t>(state.range(0));
-    coords_instance = Coordinates(state.range(0), state.range(1), BOXSIZE, state.range(1));
-    
+
+    InitCoords(state.range(0), state.range(1), BOXSIZE, state.range(1));
+  }
+  // coordinates range from 0 - delta to BOXSIZE + delta
+  void InitCoords(const int n_results, const int n_indicies,
+                  const double boxsize, const double delta) {
+
+    nresults = n_results;
+    ncoords = 3 * nresults;
+    nindicies = n_indicies;
+    nidx_results = n_indicies / 2;
+
+    coords0 = new T[ncoords];
+    coords1 = new T[ncoords];
+    ref = new T[nresults];
+    results = new T[nresults];
+    idxs = new std::size_t[nindicies];
+
+    RandomFloatingPoint<T>(coords0, ncoords, 0 - delta, boxsize + delta);
+    RandomFloatingPoint<T>(coords1, ncoords, 0 - delta, boxsize + delta);
+
+    box[0] = boxsize;
+    box[1] = boxsize;
+    box[2] = boxsize;
+
+    // triclinic box
+    // [30, 30, 30, 70, 110, 95]  in L ,M, N alpha, beta, gamma format
+    // in matrix form
+
+    triclinic_box[0] = 30;
+    triclinic_box[1] = 0;
+    triclinic_box[2] = 0;
+    triclinic_box[3] = -2.6146722;
+    triclinic_box[4] = 29.885841;
+    triclinic_box[5] = 0;
+    triclinic_box[6] = -10.260604;
+    triclinic_box[7] = 9.402112;
+    triclinic_box[8] = 26.576687;
+
+    RandomInt(idxs, nindicies, 0, nindicies - 1);
   }
 
+  void TearDown(const ::benchmark::State &state) override {
+    if (coords0) {
+      delete[] coords0;
+    }
+    if (coords1) {
+      delete[] coords1;
+    }
+    if (ref) {
+      delete[] ref;
+    }
+
+    if (results) {
+      delete[] results;
+    }
+
+    if (idxs) {
+      delete[] idxs;
+    }
+  }
 
   // members
-  Coordinates coords_instance;
+  int ncoords;
+  int nresults;
+  int nindicies;
+  int nidx_results;
+
+  T *coords0 = nullptr;
+  T *coords1 = nullptr;
+  T *ref = nullptr;
+  T *results = nullptr;
+  T box[3];
+  T triclinic_box[9];
+  std::size_t *idxs = nullptr;
 
   void BM_calc_bonds(benchmark::State &state) {
     for (auto _ : state) {
-        distopia::CalcBondsNoBox(coords_instance.coords0, coords_instance.coords1, coords_instance.nresults, coords_instance.results);
+        distopia::CalcBondsNoBox(coords0, coords1, nresults, results);
     }
-    state.SetItemsProcessed(coords_instance.nresults * state.iterations());
+    state.SetItemsProcessed(nresults * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
-        coords_instance.nresults * state.iterations(),
+        nresults * state.iterations(),
         benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
   }
 
   void BM_calc_bonds_ortho(benchmark::State &state) {
     for (auto _ : state) {
-        distopia::CalcBondsOrtho(coords_instance.coords0, coords_instance.coords1, coords_instance.nresults, coords_instance.box, coords_instance.results);
+        distopia::CalcBondsOrtho(coords0, coords1, nresults, box, results);
     }
     state.SetItemsProcessed(nresults * state.iterations());
     state.counters["Per Result"] = benchmark::Counter(
-        coords_instance.nresults * state.iterations(),
+        nresults * state.iterations(),
         benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
   }
 
   void BM_calc_bonds_triclinic(benchmark::State &state) {
       for (auto _ : state) {
-          distopia::CalcBondsTriclinic(coords_instance.coords0, coords_instance.coords1, coords_instance.nresults, coords_instance.triclinic_box, coords_instance.results);
+          distopia::CalcBondsTriclinic(coords0, coords1, nresults, triclinic_box, results);
       }
       state.SetItemsProcessed(nresults * state.iterations());
       state.counters["Per Result"] = benchmark::Counter(
-              coords_instance.nresults * state.iterations(),
+              nresults * state.iterations(),
               benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
   }
 };
 
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsInBoxFloat,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsInBoxFloat,
                             float)
 (benchmark::State &state) { BM_calc_bonds(state); }
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsInBoxFloat)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsInBoxFloat)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
 
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsInBoxDouble,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsInBoxDouble,
                             double)
 (benchmark::State &state) { BM_calc_bonds(state); }
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsInBoxDouble)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsInBoxDouble)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
 
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsOrthoInBoxFloat,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsOrthoInBoxFloat,
                             float)
 (benchmark::State &state) { BM_calc_bonds_ortho(state); }
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsOrthoInBoxFloat)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsOrthoInBoxFloat)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
 
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsOrthoInBoxDouble,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsOrthoInBoxDouble,
                             double)
 (benchmark::State &state) { BM_calc_bonds_ortho(state); }
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsOrthoInBoxDouble)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsOrthoInBoxDouble)
     ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
     ->RangeMultiplier(4);
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsOrthoOutBoxFloat,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsOrthoOutBoxFloat,
                             float)
 (benchmark::State &state) { BM_calc_bonds_ortho(state); }
 
 
 // coords can be +- 5 over boxlength
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsOrthoOutBoxFloat)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsOrthoOutBoxFloat)
         ->Ranges({{16, 16 << 12}, {0, 0}, {5, 5}})
         ->RangeMultiplier(4);
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsOrthoOutBoxDouble,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsOrthoOutBoxDouble,
                             double)
 (benchmark::State &state) { BM_calc_bonds_ortho(state); }
 
 // coords can be +- 5 over boxlength
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsOrthoOutBoxDouble)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsOrthoOutBoxDouble)
     ->Ranges({{16, 16 << 12}, {0, 0}, {5, 5}})
     ->RangeMultiplier(4);
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsTriclinicInBoxFloat,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsTriclinicInBoxFloat,
                             float)
 (benchmark::State &state) { BM_calc_bonds_triclinic(state); }
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsTriclinicInBoxFloat)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsTriclinicInBoxFloat)
         ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
         ->RangeMultiplier(4);
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsTriclinicInBoxDouble,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsTriclinicInBoxDouble,
                             double)
 (benchmark::State &state) { BM_calc_bonds_triclinic(state); }
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsTriclinicInBoxDouble)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsTriclinicInBoxDouble)
         ->Ranges({{16, 16 << 12}, {0, 0}, {0, 0}})
         ->RangeMultiplier(4);
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsTriclinicOutBoxFloat,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsTriclinicOutBoxFloat,
                             float)
 (benchmark::State &state) { BM_calc_bonds_triclinic(state); }
 
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsTriclinicOutBoxFloat)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsTriclinicOutBoxFloat)
         ->Ranges({{16, 16 << 12}, {0, 0}, {5, 5}})
         ->RangeMultiplier(4);
 
 
-BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBenchContainer, CalcBondsTriclinicOutBoxDouble,
+BENCHMARK_TEMPLATE_DEFINE_F(CoordinatesBench, CalcBondsTriclinicOutBoxDouble,
                             double)
 (benchmark::State &state) { BM_calc_bonds_triclinic(state); }
 
 
-BENCHMARK_REGISTER_F(CoordinatesBenchContainer, CalcBondsTriclinicOutBoxDouble)
+BENCHMARK_REGISTER_F(CoordinatesBench, CalcBondsTriclinicOutBoxDouble)
         ->Ranges({{16, 16 << 12}, {0, 0}, {5, 5}})
         ->RangeMultiplier(4);
 

--- a/libdistopia/test/compare/calc_distances.h
+++ b/libdistopia/test/compare/calc_distances.h
@@ -1,0 +1,916 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode:nil; -*- */
+/* vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4 */
+/*
+ MDAnalysis --- https://www.mdanalysis.org
+ Copyright (c) 2006-2017 The MDAnalysis Development Team and contributors
+ (see the file AUTHORS for the full list of names)
+
+ Released under the GNU Public Licence, v2 or any higher version
+
+ Please cite your use of MDAnalysis in published work:
+
+ R. J. Gowers, M. Linke, J. Barnoud, T. J. E. Reddy, M. N. Melo, S. L. Seyler,
+ D. L. Dotson, J. Domanski, S. Buchoux, I. M. Kenney, and O. Beckstein.
+ MDAnalysis: A Python package for the rapid analysis of molecular dynamics
+ simulations. In S. Benthall and S. Rostrup editors, Proceedings of the 15th
+ Python in Science Conference, pages 102-109, Austin, TX, 2016. SciPy.
+ doi: 10.25080/majora-629e541a-00e
+
+ N. Michaud-Agrawal, E. J. Denning, T. B. Woolf, and O. Beckstein.
+ MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.
+ J. Comput. Chem. 32 (2011), 2319--2327, doi:10.1002/jcc.21787
+*/
+
+#ifndef __DISTANCES_H
+#define __DISTANCES_H
+
+#include <math.h>
+
+#include <float.h>
+
+
+typedef float fcoordinate[3];
+typedef double dcoordinate[3];
+
+
+template <typename ScalarT>
+struct ScalarToCoordinateTStruct;
+
+// map each scalar to matching coordinate
+template <>
+struct ScalarToCoordinateTStruct<float>
+{
+    using type = fcoordinate;
+};
+template <>
+struct ScalarToCoordinateTStruct<double>
+{
+    using type = dcoordinate;
+};
+
+
+template <typename ScalarT>
+using ScalarToCoordinateT = typename ScalarToCoordinateTStruct<ScalarT>::type;
+
+
+#ifdef PARALLEL
+  #include <omp.h>
+  #define USED_OPENMP 1
+#else
+  #define USED_OPENMP 0
+#endif
+
+
+template <typename T, typename U>
+void minimum_image(T* x, U* box, U* inverse_box)
+{
+  int i;
+  T s;
+  for (i=0; i<3; i++) {
+    if (box[i] > FLT_EPSILON) {
+      s = inverse_box[i] * x[i];
+      x[i] = box[i] * (s - round(s));
+    }
+  }
+}
+
+template <typename T, typename U>
+inline void _minimum_image_ortho_lazy(T* x, U* box, U* half_box)
+{
+   /*
+    * Lazy minimum image convention for orthorhombic boxes.
+    *
+    * Assumes that the maximum separation is less than 1.5 times the box length.
+    */
+    for (int i = 0; i < 3; ++i) {
+        if (x[i] > half_box[i]) {
+            x[i] -= box[i];
+        }
+        else
+        {
+            if (x[i] <= -half_box[i])
+            {
+                x[i] += box[i];
+            }
+        }
+    }
+}
+
+template <typename T, typename U>
+void minimum_image_triclinic(T* dx, U* box)
+{
+   /*
+    * Minimum image convention for triclinic systems, modelled after domain.cpp
+    * in LAMMPS.
+    * Assumes that there is a maximum separation of 1 box length (enforced in
+    * dist functions by moving all particles to inside the box before
+    * calculating separations).
+    * Assumes box having zero values for box[1], box[2] and box[5]:
+    *   /  a_x   0    0   \                 /  0    1    2  \
+    *   |  b_x  b_y   0   |       indices:  |  3    4    5  |
+    *   \  c_x  c_y  c_z  /                 \  6    7    8  /
+    */
+    T dx_min[3] = {0.0, 0.0, 0.0};
+    T dsq_min = FLT_MAX;
+    T dsq;
+    T rx;
+    T ry[2];
+    T rz[3];
+    int ix, iy, iz;
+    for (ix = -1; ix < 2; ++ix) {
+        rx = dx[0] + box[0] * ix;
+        for (iy = -1; iy < 2; ++iy) {
+            ry[0] = rx + box[3] * iy;
+            ry[1] = dx[1] + box[4] * iy;
+            for (iz = -1; iz < 2; ++iz) {
+                rz[0] = ry[0] + box[6] * iz;
+                rz[1] = ry[1] + box[7] * iz;
+                rz[2] = dx[2] + box[8] * iz;
+                dsq = rz[0] * rz[0] + rz[1] * rz[1] + rz[2] * rz[2];
+                if (dsq < dsq_min) {
+                    dsq_min = dsq;
+                    dx_min[0] = rz[0];
+                    dx_min[1] = rz[1];
+                    dx_min[2] = rz[2];
+                }
+            }
+        }
+    }
+    dx[0] = dx_min[0];
+    dx[1] = dx_min[1];
+    dx[2] = dx_min[2];
+}
+
+
+template <typename T, typename U>
+static void _ortho_pbc(ScalarToCoordinateT<T>* coords, uint64_t numcoords, U* box)
+{
+   /*
+    * Moves all coordinates to within the box boundaries for an orthogonal box.
+    *
+    * This routine first shifts coordinates by at most one box if necessary.
+    * If that is not enough, the number of required box shifts is computed and
+    * a multi-box shift is applied instead. The single shift is faster, usually
+    * enough and more accurate since the estimation of the number of required
+    * box shifts is error-prone if particles reside exactly on a box boundary.
+    * In order to guarantee that coordinates lie strictly within the primary
+    * image, multi-box shifts are always checked for accuracy and a subsequent
+    * single-box shift is applied where necessary.
+    */
+
+    // nothing to do if the box is all-zeros:
+    if (!box[0] && !box[1] && !box[2]) {
+        return;
+    }
+
+    // inverse box for multi-box shifts:
+    const U inverse_box[3] = {1.0 / (U) box[0], \
+                                   1.0 / (U) box[1], \
+                                   1.0 / (U) box[2]};
+
+   /*
+    * NOTE FOR DEVELOPERS:
+    * The order of operations matters due to numerical precision. A coordinate
+    * residing just below the lower bound of the box might get shifted exactly
+    * to the upper bound!
+    * Example: -0.0000001 + 10.0 == 10.0 (in single precision)
+    * It is therefore important to *first* check for the lower bound and
+    * afterwards *always* for the upper bound.
+    */
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(coords)
+#endif
+    for (uint64_t i = 0; i < numcoords; i++) {
+        for (int j = 0; j < 3; j++) {
+            T crd = coords[i][j];
+            if (crd < 0.0f) {
+                crd += box[j];
+                // check if multi-box shifts are required:
+                if (crd < 0.0f) {
+                    int s = floor(coords[i][j] * inverse_box[j]);
+                    coords[i][j] -= s * box[j];
+                    // multi-box shifts might be inexact, so check again:
+                    if (coords[i][j] < 0.0f) {
+                        coords[i][j] += box[j];
+                    }
+                }
+                else {
+                    coords[i][j] = crd;
+                }
+            }
+            // Don't put an "else" before this! (see note)
+            if (crd >= box[j]) {
+                crd -= box[j];
+                // check if multi-box shifts are required:
+                if (crd >= box[j]) {
+                    int s = floor(coords[i][j] * inverse_box[j]);
+                    coords[i][j] -= s * box[j];
+                    // multi-box shifts might be inexact, so check again:
+                    if (coords[i][j] >= box[j]) {
+                        coords[i][j] -= box[j];
+                    }
+                }
+                else {
+                    coords[i][j] = crd;
+                }
+            }
+        }
+    }
+}
+
+template <typename T, typename U>
+static void _triclinic_pbc(ScalarToCoordinateT<T>* coords, uint64_t numcoords, U* box)
+{
+   /* Moves all coordinates to within the box boundaries for a triclinic box.
+    * Assumes that the box has zero values for box[1], box[2] and box[5]:
+    *   [ a_x,   0,   0 ]                 [ 0, 1, 2 ]
+    *   [ b_x, b_y,   0 ]       indices:  [ 3, 4, 5 ]
+    *   [ c_x, c_y, c_z ]                 [ 6, 7, 8 ]
+    *
+    * Inverse of matrix box (here called "m"):
+    *   [                       1/m0,           0,    0 ]
+    *   [                -m3/(m0*m4),        1/m4,    0 ]
+    *   [ (m3*m7/(m0*m4) - m6/m0)/m8, -m7/(m4*m8), 1/m8 ]
+    *
+    * This routine first shifts coordinates by at most one box if necessary.
+    * If that is not enough, the number of required box shifts is computed and
+    * a multi-box shift is applied instead. The single shift is faster, usually
+    * enough and more accurate since the estimation of the number of required
+    * box shifts is error-prone if particles reside exactly on a box boundary.
+    * In order to guarantee that coordinates lie strictly within the primary
+    * image, multi-box shifts are always checked for accuracy and a subsequent
+    * single-box shift is applied where necessary.
+    */
+
+    // nothing to do if the box diagonal is all-zeros:
+    if (!box[0] && !box[4] && !box[8]) {
+        return;
+    }
+
+    // constants for multi-box shifts:
+    const T bi0 = 1.0 / (T) box[0];
+    const T bi4 = 1.0 / (T) box[4];
+    const T bi8 = 1.0 / (T) box[8];
+    const T bi3 = -box[3] * bi0 * bi4;
+    const T bi6 = (-bi3 * box[7] - box[6] * bi0) * bi8;
+    const T bi7 = -box[7] * bi4 * bi8;
+    // variables and constants for single box shifts:
+    const T a_ax_yfactor = (T) box[3] * bi4;;
+    const T a_ax_zfactor = (T) box[6] * bi8;
+    const T b_ax_zfactor = (T) box[7] * bi8;
+
+
+   /*
+    * NOTE FOR DEVELOPERS:
+    * The order of operations matters due to numerical precision. A coordinate
+    * residing just below the lower bound of the box might get shifted exactly
+    * to the upper bound!
+    * Example: -0.0000001 + 10.0 == 10.0 (in single precision)
+    * It is therefore important to *first* check for the lower bound and
+    * afterwards *always* for the upper bound.
+    */
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(coords)
+#endif
+    for (uint64_t i = 0; i < numcoords; i++) {
+        int msr = 0;
+        T crd[3];
+        T lbound, ubound;
+        
+        crd[0] = coords[i][0];
+        crd[1] = coords[i][1];
+        crd[2] = coords[i][2];
+        // translate coords[i] to central cell along c-axis
+        if (crd[2] < 0.0f) {
+            crd[0] += box[6];
+            crd[1] += box[7];
+            crd[2] += box[8];
+            // check if multi-box shifts are required:
+            if (crd[2] < 0.0f) {
+                msr = 1;
+            }
+        }
+        // Don't put an "else" before this! (see note)
+        if (crd[2] >= box[8]) {
+            crd[0] -= box[6];
+            crd[1] -= box[7];
+            crd[2] -= box[8];
+            // check if multi-box shifts are required:
+            if (crd[2] >= box[8]) {
+                msr = 1;
+            }
+        }
+        if (!msr) {
+            // translate remainder of crd to central cell along b-axis
+            lbound = crd[2] * b_ax_zfactor;
+            ubound = lbound + box[4];
+            if (crd[1] < lbound) {
+                crd[0] += box[3];
+                crd[1] += box[4];
+                // check if multi-box shifts are required:
+                if (crd[1] < lbound) {
+                    msr = 1;
+                }
+            }
+            // Don't put an "else" before this! (see note)
+            if (crd[1] >= ubound) {
+                crd[0] -= box[3];
+                crd[1] -= box[4];
+                // check if multi-box shifts are required:
+                if (crd[1] >= ubound) {
+                    msr = 1;
+                }
+            }
+            if (!msr) {
+                // translate remainder of crd to central cell along a-axis
+                lbound = crd[1] * a_ax_yfactor + crd[2] * a_ax_zfactor;
+                ubound = lbound + box[0];
+                if (crd[0] < lbound) {
+                    crd[0] += box[0];
+                    // check if multi-box shifts are required:
+                    if (crd[0] < lbound) {
+                        msr = 1;
+                    }
+                }
+                // Don't put an "else" before this! (see note)
+                if (crd[0] >= ubound) {
+                    crd[0] -= box[0];
+                    // check if multi-box shifts are required:
+                    if (crd[0] >= ubound) {
+                        msr = 1;
+                    }
+                }
+            }
+        }
+        // multi-box shifts required?
+        if (msr) {
+            // translate coords[i] to central cell along c-axis
+            int s = floor(coords[i][2] * bi8);
+            coords[i][2] -= s * box[8];
+            coords[i][1] -= s * box[7];
+            coords[i][0] -= s * box[6];
+            // translate remainder of coords[i] to central cell along b-axis
+            s = floor(coords[i][1] * bi4 + coords[i][2] * bi7);
+            coords[i][1] -= s * box[4];
+            coords[i][0] -= s * box[3];
+            // translate remainder of coords[i] to central cell along a-axis
+            s = floor(coords[i][0] * bi0 + coords[i][1] * bi3 + coords[i][2] * bi6);
+            coords[i][0] -= s * box[0];
+            // multi-box shifts might be inexact, so check again:
+            crd[0] = coords[i][0];
+            crd[1] = coords[i][1];
+            crd[2] = coords[i][2];
+            // translate coords[i] to central cell along c-axis
+            if (crd[2] < 0.0f) {
+                crd[0] += box[6];
+                crd[1] += box[7];
+                crd[2] += box[8];
+            }
+            // Don't put an "else" before this! (see note)
+            if (crd[2] >= box[8]) {
+                crd[0] -= box[6];
+                crd[1] -= box[7];
+                crd[2] -= box[8];
+            }
+            // translate remainder of crd to central cell along b-axis
+            lbound = crd[2] * b_ax_zfactor;
+            ubound = lbound + box[4];
+            if (crd[1] < lbound) {
+                crd[0] += box[3];
+                crd[1] += box[4];
+            }
+            // Don't put an "else" before this! (see note)
+            if (crd[1] >= ubound) {
+                crd[0] -= box[3];
+                crd[1] -= box[4];
+            }
+            // translate remainder of crd to central cell along a-axis
+            lbound = crd[1] * a_ax_yfactor + crd[2] * a_ax_zfactor;
+            ubound = lbound + box[0];
+            if (crd[0] < lbound) {
+                crd[0] += box[0];
+            }
+            // Don't put an "else" before this! (see note)
+            if (crd[0] >= ubound) {
+                crd[0] -= box[0];
+            }
+            coords[i][0] = crd[0];
+            coords[i][1] = crd[1];
+            coords[i][2] = crd[2];
+        }
+        // single shift was sufficient, apply the result:
+        else {
+            coords[i][0] = crd[0];
+            coords[i][1] = crd[1];
+            coords[i][2] = crd[2];
+        }
+    }
+}
+
+template <typename T, typename U>
+static void _calc_distance_array(ScalarToCoordinateT<T>* ref, uint64_t numref, ScalarToCoordinateT<T>* conf,
+                                 uint64_t numconf, T* distances)
+{
+#ifdef PARALLEL
+#pragma omp parallel for shared(distances)
+#endif
+  for (uint64_t i = 0; i < numref; i++) {
+    for (uint64_t j = 0; j < numconf; j++) {
+      T dx[3];
+      dx[0] = conf[j][0] - ref[i][0];
+      dx[1] = conf[j][1] - ref[i][1];
+      dx[2] = conf[j][2] - ref[i][2];
+      T rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      *(distances+i*numconf+j) = sqrt(rsq);
+    }
+  }
+}
+
+template <typename T, typename U>
+static void _calc_distance_array_ortho(ScalarToCoordinateT<T>* ref, uint64_t numref, ScalarToCoordinateT<T>* conf,
+                                       uint64_t numconf, U* box, T* distances)
+{
+  U inverse_box[3];
+  inverse_box[0] = 1.0 / box[0];
+  inverse_box[1] = 1.0 / box[1];
+  inverse_box[2] = 1.0 / box[2];
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(distances)
+#endif
+  for (uint64_t i = 0; i < numref; i++) {
+    for (uint64_t j = 0; j < numconf; j++) {
+      T dx[3];
+      dx[0] = conf[j][0] - ref[i][0];
+      dx[1] = conf[j][1] - ref[i][1];
+      dx[2] = conf[j][2] - ref[i][2];
+      // Periodic boundaries
+      minimum_image(dx, box, inverse_box);
+      T rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      *(distances+i*numconf+j) = sqrt(rsq);
+    }
+  }
+}
+
+template <typename T, typename U>
+static void _calc_distance_array_triclinic(ScalarToCoordinateT<T>* ref, uint64_t numref,
+                                           ScalarToCoordinateT<T>* conf, uint64_t numconf,
+                                           U* box, T* distances)
+{
+  // Move coords to inside box
+  _triclinic_pbc(ref, numref, box);
+  _triclinic_pbc(conf, numconf, box);
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(distances)
+#endif
+  for (uint64_t i = 0; i < numref; i++) {
+    for (uint64_t j = 0; j < numconf; j++) {
+      T dx[3];
+      dx[0] = conf[j][0] - ref[i][0];
+      dx[1] = conf[j][1] - ref[i][1];
+      dx[2] = conf[j][2] - ref[i][2];
+      minimum_image_triclinic(dx, box);
+      T rsq = (dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+      *(distances + i*numconf + j) = sqrt(rsq);
+    }
+  }
+}
+
+template <typename T>
+static void _calc_self_distance_array(ScalarToCoordinateT<T>* ref, uint64_t numref,
+                                      T* distances)
+{
+    uint64_t distpos = 0;
+#ifdef PARALLEL
+#pragma omp parallel for private(distpos) shared(distances)
+#endif
+  for (uint64_t i = 0; i < numref; i++) {
+#ifdef PARALLEL
+    distpos =
+        i * (2 * numref - i - 1) / 2; // calculates the offset into distances
+#endif
+    for (uint64_t j = i + 1; j < numref; j++) {
+      T dx[3];
+      dx[0] = ref[j][0] - ref[i][0];
+      dx[1] = ref[j][1] - ref[i][1];
+      dx[2] = ref[j][2] - ref[i][2];
+      T rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      *(distances+distpos) = sqrt(rsq);
+      distpos += 1;
+    }
+  }
+}
+
+template <typename T, typename U>
+static void _calc_self_distance_array_ortho(ScalarToCoordinateT<T>* ref, uint64_t numref,
+                                            U* box, T* distances)
+{
+  U inverse_box[3];
+
+  inverse_box[0] = 1.0 / box[0];
+  inverse_box[1] = 1.0 / box[1];
+  inverse_box[2] = 1.0 / box[2];
+
+  uint64_t distpos = 0;
+
+#ifdef PARALLEL
+#pragma omp parallel for private(distpos) shared(distances)
+#endif
+  for (uint64_t i = 0; i < numref; i++) {
+#ifdef PARALLEL
+    distpos =
+        i * (2 * numref - i - 1) / 2; // calculates the offset into distances
+#endif
+    for (uint64_t j = i + 1; j < numref; j++) {
+      T dx[3];
+      dx[0] = ref[j][0] - ref[i][0];
+      dx[1] = ref[j][1] - ref[i][1];
+      dx[2] = ref[j][2] - ref[i][2];
+      // Periodic boundaries
+      minimum_image(dx, box, inverse_box);
+      T rsq = (dx[0]*dx[0]) + (dx[1]*dx[1]) + (dx[2]*dx[2]);
+      *(distances+distpos) = sqrt(rsq);
+      distpos += 1;
+    }
+  }
+}
+
+
+
+template <typename T, typename U>
+static void _calc_self_distance_array_triclinic(ScalarToCoordinateT<T>* ref, uint64_t numref,
+                                                U* box, T *distances)
+{
+  _triclinic_pbc(ref, numref, box);
+
+  uint64_t distpos = 0;
+
+#ifdef PARALLEL
+#pragma omp parallel for private(distpos) shared(distances)
+#endif
+  for (uint64_t i = 0; i < numref; i++) {
+#ifdef PARALLEL
+    distpos =
+        i * (2 * numref - i - 1) / 2; // calculates the offset into distances
+#endif
+    for (uint64_t j = i + 1; j < numref; j++) {
+      T dx[3];
+      dx[0] = ref[j][0] - ref[i][0];
+      dx[1] = ref[j][1] - ref[i][1];
+      dx[2] = ref[j][2] - ref[i][2];
+      minimum_image_triclinic(dx, box);
+      T rsq = (dx[0]*dx[0] + dx[1]*dx[1] + dx[2]*dx[2]);
+      *(distances + distpos) = sqrt(rsq);
+      distpos += 1;
+    }
+  }
+}
+
+template <typename T, typename U>
+void _coord_transform(ScalarToCoordinateT<T>* coords, uint64_t numCoords, U* box)
+{
+  // Matrix multiplication inCoords * box = outCoords
+  // Multiplication done in place using temp array 'new'
+  // Used to transform coordinates to/from S/R space in trilinic boxes
+#ifdef PARALLEL
+#pragma omp parallel for shared(coords)
+#endif
+  for (uint64_t i = 0; i < numCoords; i++) {
+    T newpos[3];
+    newpos[0] = 0.0;
+    newpos[1] = 0.0;
+    newpos[2] = 0.0;
+    for (uint64_t j = 0; j < 3; j++) {
+      for (uint64_t k = 0; k < 3; k++) {
+        newpos[j] += coords[i][k] * box[3 * k + j];
+      }
+    }
+    coords[i][0] = newpos[0];
+    coords[i][1] = newpos[1];
+    coords[i][2] = newpos[2];
+  }
+}
+
+template <typename T>
+static void _calc_bond_distance(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                                uint64_t numatom, T* distances)
+{
+#ifdef PARALLEL
+#pragma omp parallel for shared(distances)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T dx[3];
+    dx[0] = atom1[i][0] - atom2[i][0];
+    dx[1] = atom1[i][1] - atom2[i][1];
+    dx[2] = atom1[i][2] - atom2[i][2];
+    T rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
+    *(distances+i) = sqrt(rsq);
+  }
+}
+
+template <typename T, typename U>
+static void _calc_bond_distance_ortho(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                                      uint64_t numatom, U* box, T* distances)
+{
+  U inverse_box[3];
+
+  inverse_box[0] = 1.0/box[0];
+  inverse_box[1] = 1.0/box[1];
+  inverse_box[2] = 1.0/box[2];
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(distances)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T dx[3];
+    dx[0] = atom1[i][0] - atom2[i][0];
+    dx[1] = atom1[i][1] - atom2[i][1];
+    dx[2] = atom1[i][2] - atom2[i][2];
+    // PBC time!
+    minimum_image(dx, box, inverse_box);
+    T rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
+    *(distances+i) = sqrt(rsq);
+  }
+}
+
+template <typename T, typename U>
+static void _calc_bond_distance_triclinic(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                                          uint64_t numatom, U* box,
+                                          T* distances)
+{
+  _triclinic_pbc(atom1, numatom, box);
+  _triclinic_pbc(atom2, numatom, box);
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(distances)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T dx[3];
+    dx[0] = atom1[i][0] - atom2[i][0];
+    dx[1] = atom1[i][1] - atom2[i][1];
+    dx[2] = atom1[i][2] - atom2[i][2];
+    // PBC time!
+    minimum_image_triclinic(dx, box);
+    T rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
+    *(distances+i) = sqrt(rsq);
+  }
+}
+
+template <typename T>
+static void _calc_angle(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                        ScalarToCoordinateT<T>* atom3, uint64_t numatom, T* angles)
+{
+#ifdef PARALLEL
+#pragma omp parallel for shared(angles)
+#endif
+  for (uint64_t i=0; i<numatom; i++) {
+    T rji[3], rjk[3], xp[3];
+
+    rji[0] = atom1[i][0] - atom2[i][0];
+    rji[1] = atom1[i][1] - atom2[i][1];
+    rji[2] = atom1[i][2] - atom2[i][2];
+
+    rjk[0] = atom3[i][0] - atom2[i][0];
+    rjk[1] = atom3[i][1] - atom2[i][1];
+    rjk[2] = atom3[i][2] - atom2[i][2];
+
+    T x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
+
+    xp[0] = rji[1]*rjk[2] - rji[2]*rjk[1];
+    xp[1] =-rji[0]*rjk[2] + rji[2]*rjk[0];
+    xp[2] = rji[0]*rjk[1] - rji[1]*rjk[0];
+
+    T y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
+
+    *(angles+i) = atan2(y,x);
+  }
+}
+
+template <typename T, typename U>
+static void _calc_angle_ortho(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                              ScalarToCoordinateT<T>* atom3, uint64_t numatom,
+                              U* box, T* angles)
+{
+  // Angle is calculated between two vectors
+  // pbc option ensures that vectors are constructed between atoms in the same image as eachother
+  // ie that vectors don't go across a boxlength
+  // it doesn't matter if vectors are from different boxes however
+  U inverse_box[3];
+
+  inverse_box[0] = 1.0/box[0];
+  inverse_box[1] = 1.0/box[1];
+  inverse_box[2] = 1.0/box[2];
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(angles)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T rji[3], rjk[3], xp[3];
+
+    rji[0] = atom1[i][0] - atom2[i][0];
+    rji[1] = atom1[i][1] - atom2[i][1];
+    rji[2] = atom1[i][2] - atom2[i][2];
+    minimum_image(rji, box, inverse_box);
+
+    rjk[0] = atom3[i][0] - atom2[i][0];
+    rjk[1] = atom3[i][1] - atom2[i][1];
+    rjk[2] = atom3[i][2] - atom2[i][2];
+    minimum_image(rjk, box, inverse_box);
+
+    T x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
+
+    xp[0] = rji[1]*rjk[2] - rji[2]*rjk[1];
+    xp[1] =-rji[0]*rjk[2] + rji[2]*rjk[0];
+    xp[2] = rji[0]*rjk[1] - rji[1]*rjk[0];
+
+    T y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
+
+    *(angles+i) = atan2(y,x);
+  }
+}
+
+
+template <typename T, typename U>
+static void _calc_angle_triclinic(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                                  ScalarToCoordinateT<T>* atom3, uint64_t numatom,
+                                  U* box, T* angles)
+{
+  // Triclinic version of min image aware angle calculate, see above
+  _triclinic_pbc(atom1, numatom, box);
+  _triclinic_pbc(atom2, numatom, box);
+  _triclinic_pbc(atom3, numatom, box);
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(angles)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T rji[3], rjk[3], xp[3];
+
+    rji[0] = atom1[i][0] - atom2[i][0];
+    rji[1] = atom1[i][1] - atom2[i][1];
+    rji[2] = atom1[i][2] - atom2[i][2];
+    minimum_image_triclinic(rji, box);
+
+    rjk[0] = atom3[i][0] - atom2[i][0];
+    rjk[1] = atom3[i][1] - atom2[i][1];
+    rjk[2] = atom3[i][2] - atom2[i][2];
+    minimum_image_triclinic(rjk, box);
+
+    T x = rji[0]*rjk[0] + rji[1]*rjk[1] + rji[2]*rjk[2];
+
+    xp[0] = rji[1]*rjk[2] - rji[2]*rjk[1];
+    xp[1] =-rji[0]*rjk[2] + rji[2]*rjk[0];
+    xp[2] = rji[0]*rjk[1] - rji[1]*rjk[0];
+
+    T y = sqrt(xp[0]*xp[0] + xp[1]*xp[1] + xp[2]*xp[2]);
+
+    *(angles+i) = atan2(y,x);
+  }
+}
+
+
+template <typename T>
+static void _calc_dihedral_angle(T* va, T* vb, T* vc, T* result)
+{
+  // Returns atan2 from vectors va, vb, vc
+  T n1[3], n2[3];
+  T xp[3], vb_norm;
+  T x, y;
+
+  //n1 is normal vector to -va, vb
+  //n2 is normal vector to -vb, vc
+  n1[0] =-va[1]*vb[2] + va[2]*vb[1];
+  n1[1] = va[0]*vb[2] - va[2]*vb[0];
+  n1[2] =-va[0]*vb[1] + va[1]*vb[0];
+
+  n2[0] =-vb[1]*vc[2] + vb[2]*vc[1];
+  n2[1] = vb[0]*vc[2] - vb[2]*vc[0];
+  n2[2] =-vb[0]*vc[1] + vb[1]*vc[0];
+
+  // x = dot(n1,n2) = cos theta
+  x = (n1[0]*n2[0] + n1[1]*n2[1] + n1[2]*n2[2]);
+
+  // xp = cross(n1,n2)
+  xp[0] = n1[1]*n2[2] - n1[2]*n2[1];
+  xp[1] =-n1[0]*n2[2] + n1[2]*n2[0];
+  xp[2] = n1[0]*n2[1] - n1[1]*n2[0];
+
+  vb_norm = sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
+
+  y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / vb_norm;
+
+  if ( (fabs(x) == 0.0) && (fabs(y) == 0.0) ) // numpy consistency
+  {
+    *result = NAN;
+    return;
+  }
+
+  *result = atan2(y, x); //atan2 is better conditioned than acos
+}
+
+
+template <typename T, typename U>
+static void _calc_dihedral(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                           ScalarToCoordinateT<T>* atom3, ScalarToCoordinateT<T>* atom4,
+                           uint64_t numatom, T* angles)
+{
+#ifdef PARALLEL
+#pragma omp parallel for shared(angles)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T va[3], vb[3], vc[3];
+
+    // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
+    va[0] = atom2[i][0] - atom1[i][0];
+    va[1] = atom2[i][1] - atom1[i][1];
+    va[2] = atom2[i][2] - atom1[i][2];
+
+    vb[0] = atom3[i][0] - atom2[i][0];
+    vb[1] = atom3[i][1] - atom2[i][1];
+    vb[2] = atom3[i][2] - atom2[i][2];
+
+    vc[0] = atom4[i][0] - atom3[i][0];
+    vc[1] = atom4[i][1] - atom3[i][1];
+    vc[2] = atom4[i][2] - atom3[i][2];
+
+    _calc_dihedral_angle(va, vb, vc, angles + i);
+  }
+}
+
+
+template <typename T, typename U>
+static void _calc_dihedral_ortho(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                                 ScalarToCoordinateT<T>* atom3, ScalarToCoordinateT<T>* atom4,
+                                 uint64_t numatom, U* box, T* angles)
+{
+  T inverse_box[3];
+
+  inverse_box[0] = 1.0/box[0];
+  inverse_box[1] = 1.0/box[1];
+  inverse_box[2] = 1.0/box[2];
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(angles)
+#endif
+  for (uint64_t i = 0; i < numatom; i++) {
+    T va[3], vb[3], vc[3];
+
+    // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
+    va[0] = atom2[i][0] - atom1[i][0];
+    va[1] = atom2[i][1] - atom1[i][1];
+    va[2] = atom2[i][2] - atom1[i][2];
+    minimum_image(va, box, inverse_box);
+
+    vb[0] = atom3[i][0] - atom2[i][0];
+    vb[1] = atom3[i][1] - atom2[i][1];
+    vb[2] = atom3[i][2] - atom2[i][2];
+    minimum_image(vb, box, inverse_box);
+
+    vc[0] = atom4[i][0] - atom3[i][0];
+    vc[1] = atom4[i][1] - atom3[i][1];
+    vc[2] = atom4[i][2] - atom3[i][2];
+    minimum_image(vc, box, inverse_box);
+
+    _calc_dihedral_angle(va, vb, vc, angles + i);
+  }
+}
+
+template <typename T, typename U>
+static void _calc_dihedral_triclinic(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
+                                     ScalarToCoordinateT<T>* atom3, ScalarToCoordinateT<T>* atom4,
+                                     uint64_t numatom, U* box, T* angles)
+{
+  _triclinic_pbc(atom1, numatom, box);
+  _triclinic_pbc(atom2, numatom, box);
+  _triclinic_pbc(atom3, numatom, box);
+  _triclinic_pbc(atom4, numatom, box);
+
+#ifdef PARALLEL
+#pragma omp parallel for shared(angles)
+#endif
+  for (uint64_t  i = 0; i < numatom; i++) {
+    T va[3], vb[3], vc[3];
+
+    // connecting vectors between all 4 atoms: 1 -va-> 2 -vb-> 3 -vc-> 4
+    va[0] = atom2[i][0] - atom1[i][0];
+    va[1] = atom2[i][1] - atom1[i][1];
+    va[2] = atom2[i][2] - atom1[i][2];
+    minimum_image_triclinic(va, box);
+
+    vb[0] = atom3[i][0] - atom2[i][0];
+    vb[1] = atom3[i][1] - atom2[i][1];
+    vb[2] = atom3[i][2] - atom2[i][2];
+    minimum_image_triclinic(vb, box);
+
+    vc[0] = atom4[i][0] - atom3[i][0];
+    vc[1] = atom4[i][1] - atom3[i][1];
+    vc[2] = atom4[i][2] - atom3[i][2];
+    minimum_image_triclinic(vc, box);
+
+    _calc_dihedral_angle(va, vb, vc, angles + i);
+  }
+}
+#endif

--- a/libdistopia/test/compare/calc_distances.h
+++ b/libdistopia/test/compare/calc_distances.h
@@ -641,8 +641,8 @@ static void _calc_bond_distance_triclinic(ScalarToCoordinateT<T>* atom1, ScalarT
                                           uint64_t numatom, U* box,
                                           T* distances)
 {
-  _triclinic_pbc(atom1, numatom, box);
-  _triclinic_pbc(atom2, numatom, box);
+  _triclinic_pbc<T, U>(atom1, numatom, box);
+  _triclinic_pbc<T, U>(atom2, numatom, box);
 
 #ifdef PARALLEL
 #pragma omp parallel for shared(distances)
@@ -653,7 +653,7 @@ static void _calc_bond_distance_triclinic(ScalarToCoordinateT<T>* atom1, ScalarT
     dx[1] = atom1[i][1] - atom2[i][1];
     dx[2] = atom1[i][2] - atom2[i][2];
     // PBC time!
-    minimum_image_triclinic(dx, box);
+    minimum_image_triclinic<T,U>(dx, box);
     T rsq = (dx[0]*dx[0])+(dx[1]*dx[1])+(dx[2]*dx[2]);
     *(distances+i) = sqrt(rsq);
   }
@@ -801,7 +801,6 @@ static void _calc_dihedral_angle(T* va, T* vb, T* vc, T* result)
   vb_norm = sqrt(vb[0]*vb[0] + vb[1]*vb[1] + vb[2]*vb[2]);
 
   y = (xp[0]*vb[0] + xp[1]*vb[1] + xp[2]*vb[2]) / vb_norm;
-
   if ( (fabs(x) == 0.0) && (fabs(y) == 0.0) ) // numpy consistency
   {
     *result = NAN;
@@ -812,7 +811,7 @@ static void _calc_dihedral_angle(T* va, T* vb, T* vc, T* result)
 }
 
 
-template <typename T, typename U>
+template <typename T>
 static void _calc_dihedral(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>* atom2,
                            ScalarToCoordinateT<T>* atom3, ScalarToCoordinateT<T>* atom4,
                            uint64_t numatom, T* angles)
@@ -836,7 +835,7 @@ static void _calc_dihedral(ScalarToCoordinateT<T>* atom1, ScalarToCoordinateT<T>
     vc[1] = atom4[i][1] - atom3[i][1];
     vc[2] = atom4[i][2] - atom3[i][2];
 
-    _calc_dihedral_angle(va, vb, vc, angles + i);
+    _calc_dihedral_angle<T>(va, vb, vc, angles + i);
   }
 }
 
@@ -874,7 +873,7 @@ static void _calc_dihedral_ortho(ScalarToCoordinateT<T>* atom1, ScalarToCoordina
     vc[2] = atom4[i][2] - atom3[i][2];
     minimum_image(vc, box, inverse_box);
 
-    _calc_dihedral_angle(va, vb, vc, angles + i);
+    _calc_dihedral_angle<T>(va, vb, vc, angles + i);
   }
 }
 
@@ -910,7 +909,9 @@ static void _calc_dihedral_triclinic(ScalarToCoordinateT<T>* atom1, ScalarToCoor
     vc[2] = atom4[i][2] - atom3[i][2];
     minimum_image_triclinic(vc, box);
 
-    _calc_dihedral_angle(va, vb, vc, angles + i);
+    _calc_dihedral_angle<T>(va, vb, vc, angles + i);
   }
 }
+
+
 #endif

--- a/libdistopia/test/test.cpp
+++ b/libdistopia/test/test.cpp
@@ -4,27 +4,8 @@
 
 #include "gtest/gtest.h"
 #include "distopia.h"
+#include "test_utils.h"
 
-
-// overload for scalar types
-inline void EXPECT_SCALAR_EQ(float result, float ref)
-{
-    EXPECT_FLOAT_EQ(result, ref);
-}
-
-inline void EXPECT_SCALAR_EQ(double result, double ref)
-{
-    EXPECT_DOUBLE_EQ(result, ref);
-}
-
-inline void EXPECT_SCALAR_NEAR(float result, float ref, float tol)
-{
-    EXPECT_NEAR(result, ref, tol);
-}
-inline void EXPECT_SCALAR_NEAR(double result, double ref, float tol)
-{
-    EXPECT_NEAR(result, ref, tol);
-}
 
 
 

--- a/libdistopia/test/test_fixtures.h
+++ b/libdistopia/test/test_fixtures.h
@@ -5,9 +5,10 @@
 #include "test_utils.h"
 
 
+
 template <typename T>
-class Coordinates {
-protected:
+class CoordinatesTest : public ::testing::Test {
+public:
   // members
   int ncoords;
   int nresults;
@@ -15,14 +16,16 @@ protected:
   T* coords0 = nullptr;
   T* coords1 = nullptr;
   T* coords2 = nullptr;
+  T* coords3 = nullptr;
   T* ref = nullptr;
   T* results = nullptr;
   T box[3];
+  T triclinic_box[9];
   std::size_t* idxs = nullptr;
 
-public:
-  // Constructor
-  Coordinates(const int n_results, const int n_indicies,
+
+
+  void SetUp(const int n_results, const int n_indicies,
               const double boxsize, const double delta) {
     nresults = n_results;
     ncoords = 3 * nresults;
@@ -31,6 +34,7 @@ public:
     coords0 = new T[ncoords];
     coords1 = new T[ncoords];
     coords2 = new T[ncoords];
+    coords3 = new T[ncoords];
     ref = new T[nresults];
     results = new T[nresults];
     idxs = new std::size_t[nindicies];
@@ -38,21 +42,26 @@ public:
     RandomFloatingPoint<T>(coords0, ncoords, 0 - delta, boxsize + delta);
     RandomFloatingPoint<T>(coords1, ncoords, 0 - delta, boxsize + delta);
     RandomFloatingPoint<T>(coords2, ncoords, 0 - delta, boxsize + delta);
+    RandomFloatingPoint<T>(coords3, ncoords, 0 - delta, boxsize + delta);
 
     box[0] = boxsize;
     box[1] = boxsize;
     box[2] = boxsize;
 
+
+
     for (size_t i = 0; i < nindicies; i++) {
       idxs[i] = i;
     }
+
   }
 
   // Destructor with inlined cleanup
-  ~Coordinates() override {
+  virtual void TearDown()  {
     delete[] coords0;
     delete[] coords1;
     delete[] coords2;
+    delete[] coords3;
     delete[] ref;
     delete[] results;
     delete[] idxs;
@@ -60,8 +69,8 @@ public:
 };
 
 
-template <typename T>
-class CoordinatesTest : public Coordinates<T>, public ::testing::Test
+
+
 
 
 

--- a/libdistopia/test/test_fixtures.h
+++ b/libdistopia/test/test_fixtures.h
@@ -1,0 +1,68 @@
+#ifndef DISTOPIA_TEST_FIXTURES_H
+#define DISTOPIA_TEST_FIXTURES_H
+
+#include "gtest/gtest.h"
+#include "test_utils.h"
+
+
+template <typename T>
+class Coordinates {
+protected:
+  // members
+  int ncoords;
+  int nresults;
+  int nindicies;
+  T* coords0 = nullptr;
+  T* coords1 = nullptr;
+  T* coords2 = nullptr;
+  T* ref = nullptr;
+  T* results = nullptr;
+  T box[3];
+  std::size_t* idxs = nullptr;
+
+public:
+  // Constructor
+  Coordinates(const int n_results, const int n_indicies,
+              const double boxsize, const double delta) {
+    nresults = n_results;
+    ncoords = 3 * nresults;
+    nindicies = n_indicies;
+
+    coords0 = new T[ncoords];
+    coords1 = new T[ncoords];
+    coords2 = new T[ncoords];
+    ref = new T[nresults];
+    results = new T[nresults];
+    idxs = new std::size_t[nindicies];
+
+    RandomFloatingPoint<T>(coords0, ncoords, 0 - delta, boxsize + delta);
+    RandomFloatingPoint<T>(coords1, ncoords, 0 - delta, boxsize + delta);
+    RandomFloatingPoint<T>(coords2, ncoords, 0 - delta, boxsize + delta);
+
+    box[0] = boxsize;
+    box[1] = boxsize;
+    box[2] = boxsize;
+
+    for (size_t i = 0; i < nindicies; i++) {
+      idxs[i] = i;
+    }
+  }
+
+  // Destructor with inlined cleanup
+  ~Coordinates() override {
+    delete[] coords0;
+    delete[] coords1;
+    delete[] coords2;
+    delete[] ref;
+    delete[] results;
+    delete[] idxs;
+  }
+};
+
+
+template <typename T>
+class CoordinatesTest : public Coordinates<T>, public ::testing::Test
+
+
+
+#endif // DISTOPIA_TEST_FIXTURES_H

--- a/libdistopia/test/test_mda_match.cpp
+++ b/libdistopia/test/test_mda_match.cpp
@@ -1,0 +1,71 @@
+#include <cmath>
+#include <iostream>
+#include <numeric>
+
+#include "gtest/gtest.h"
+#include "distopia.h"
+#include "test_utils.h"
+#include "test_fixtures.h"
+#include "compare/calc_distances.h"
+
+using testing::Types;
+typedef Types<float, double> ScalarTypes;
+
+
+// constants
+constexpr int BOXSIZE = 10;
+constexpr int NRESULTS = 10000;
+constexpr int NINDICIES = 1000;
+constexpr double abs_err = 1.0e-5;
+
+
+
+TYPED_TEST_SUITE(Coordinates, ScalarTypes);
+
+// coordinates in this test can overhang the edge of the box by 3 * the box
+// size.
+TYPED_TEST(Coordinates, CalcBondsOrthoMatchesMDA)
+{
+  this->InitCoords(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  _calc_bond_distance_ortho((coordinate *)this->coords0,
+                            (coordinate *)this->coords1, this->nresults,
+                            this->box, this->ref);
+  CalcBondsOrtho(this->coords0, this->coords1, this->box, this->nresults,
+                 this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}
+
+
+TYPED_TEST(Coordinates, CalcBondsNoBoxMatchesMDA)
+{
+  this->InitCoords(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  _calc_bond_distance(this->coords0, this->coords1,
+                      this->nresults, this->ref);
+  CalcBondsNoBox(this->coords0, this->coords1, this->nresults, this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}
+
+
+TYPED_TEST(Coordinates, CalcBondsNoBoxMatchesMDA)
+{
+  this->InitCoords(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  _calc_bond_distance(this->coords0, this->coords1,
+                      this->nresults, this->ref);
+  CalcBondsNoBox(this->coords0, this->coords1, this->nresults, this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}

--- a/libdistopia/test/test_mda_match.cpp
+++ b/libdistopia/test/test_mda_match.cpp
@@ -13,25 +13,28 @@ typedef Types<float, double> ScalarTypes;
 
 
 // constants
-constexpr int BOXSIZE = 10;
-constexpr int NRESULTS = 10000;
-constexpr int NINDICIES = 1000;
-constexpr double abs_err = 1.0e-5;
+constexpr int BOXSIZE = 30;
+constexpr int NRESULTS = 10;
+constexpr int NINDICIES = 5;
+constexpr double abs_err = 1.0e-4;
 
 
 
-TYPED_TEST_SUITE(Coordinates, ScalarTypes);
+
+TYPED_TEST_SUITE(CoordinatesTest, ScalarTypes);
 
 // coordinates in this test can overhang the edge of the box by 3 * the box
 // size.
-TYPED_TEST(Coordinates, CalcBondsOrthoMatchesMDA)
+TYPED_TEST(CoordinatesTest, CalcBondsOrthoMatchesMDA)
 {
-  this->InitCoords(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
 
-  _calc_bond_distance_ortho((coordinate *)this->coords0,
-                            (coordinate *)this->coords1, this->nresults,
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+  _calc_bond_distance_ortho((ctype*)this->coords0,
+                            (ctype*)this->coords1, this->nresults,
                             this->box, this->ref);
-  CalcBondsOrtho(this->coords0, this->coords1, this->box, this->nresults,
+  distopia::CalcBondsOrtho(this->coords0, this->coords1, this->nresults, this->box,
                  this->results);
 
   for (std::size_t i = 0; i < this->nresults; i++)
@@ -41,13 +44,15 @@ TYPED_TEST(Coordinates, CalcBondsOrthoMatchesMDA)
 }
 
 
-TYPED_TEST(Coordinates, CalcBondsNoBoxMatchesMDA)
+TYPED_TEST(CoordinatesTest, CalcBondsNoBoxMatchesMDA)
 {
-  this->InitCoords(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
 
-  _calc_bond_distance(this->coords0, this->coords1,
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+  _calc_bond_distance((ctype*)this->coords0, (ctype*)this->coords1,
                       this->nresults, this->ref);
-  CalcBondsNoBox(this->coords0, this->coords1, this->nresults, this->results);
+  distopia::CalcBondsNoBox(this->coords0, this->coords1, this->nresults, this->results);
 
   for (std::size_t i = 0; i < this->nresults; i++)
   {
@@ -56,16 +61,120 @@ TYPED_TEST(Coordinates, CalcBondsNoBoxMatchesMDA)
 }
 
 
-TYPED_TEST(Coordinates, CalcBondsNoBoxMatchesMDA)
-{
-  this->InitCoords(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
 
-  _calc_bond_distance(this->coords0, this->coords1,
-                      this->nresults, this->ref);
-  CalcBondsNoBox(this->coords0, this->coords1, this->nresults, this->results);
+
+TYPED_TEST(CoordinatesTest, CalcBondsTriclinicMatchesMDA)
+{
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+    // triclinic box
+    // [30, 30, 30, 70, 110, 95]  in L ,M, N alpha, beta, gamma format
+
+  this->triclinic_box[0]  = 30;
+  this->triclinic_box[1]  = 0;
+  this->triclinic_box[2]  = 0;
+  this->triclinic_box[3]  = -2.6146722;
+  this->triclinic_box[4]  = 29.885841;
+  this->triclinic_box[5]  = 0;
+  this->triclinic_box[6]  = -10.260604;
+  this->triclinic_box[7]  = 9.402112;
+  this->triclinic_box[8]  = 26.576687;
+
+    // in lower triangular  matrix form
+
+  TypeParam triclinic_box_reduced[6];
+  triclinic_box_reduced[0] = this->triclinic_box[0];
+  triclinic_box_reduced[1] = this->triclinic_box[3];
+  triclinic_box_reduced[2] = this->triclinic_box[4];
+  triclinic_box_reduced[3] = this->triclinic_box[6];
+  triclinic_box_reduced[4] = this->triclinic_box[7];
+  triclinic_box_reduced[5] = this->triclinic_box[8];
+
+  _calc_bond_distance_triclinic((ctype*)this->coords0, (ctype*)this->coords1, 
+                      this->nresults, this->triclinic_box, this->ref);
+
+  distopia::CalcBondsTriclinic(this->coords0, this->coords1, this->nresults, triclinic_box_reduced, this->results);
 
   for (std::size_t i = 0; i < this->nresults; i++)
   {
     EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
   }
 }
+
+
+
+TYPED_TEST(CoordinatesTest, CalcAnglesOrthoMatchesMDA)
+{
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+  _calc_angle_ortho((ctype*)this->coords0, (ctype*)this->coords1,
+                             (ctype*)this->coords2, this->nresults, this->box, this->ref);
+  distopia::CalcAnglesOrtho(this->coords0, this->coords1, this->coords2, this->nresults, this->box,
+                 this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}
+
+
+TYPED_TEST(CoordinatesTest, CalcAnglesNoBoxMatchesMDA)
+{
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+  _calc_angle((ctype*)this->coords0, (ctype*)this->coords1, (ctype*)this->coords2,
+                      this->nresults, this->ref);
+  distopia::CalcAnglesNoBox(this->coords0, this->coords1, this->coords2, this->nresults, this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}
+
+TYPED_TEST(CoordinatesTest, CalcAnglesTriclinicMatchesMDA)
+{
+  // triclinic box TODO: fix distances first
+}
+
+
+TYPED_TEST(CoordinatesTest, CalcDihedralsOrthoMatchesMDA)
+{
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+  _calc_dihedral_ortho((ctype*)this->coords0, (ctype*)this->coords1,
+                             (ctype*)this->coords2, (ctype*)this->coords3, this->nresults, this->box, this->ref);
+  distopia::CalcDihedralsOrtho(this->coords0, this->coords1, this->coords2, this->coords3, this->nresults, this->box, this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}
+
+
+TYPED_TEST(CoordinatesTest, CalcDihedralsNoBoxMatchesMDA)
+{
+  this->SetUp(NRESULTS, NINDICIES, BOXSIZE, 3 * BOXSIZE);
+
+  using ctype = ScalarToCoordinateT<TypeParam>;
+
+  _calc_dihedral((ctype*)this->coords0, (ctype*)this->coords1, (ctype*)this->coords2,
+                      (ctype*)this->coords3, this->nresults, this->ref);
+  distopia::CalcDihedralsNoBox(this->coords0, this->coords1, this->coords2, this->coords3, this->nresults, this->results);
+
+  for (std::size_t i = 0; i < this->nresults; i++)
+  {
+    EXPECT_NEAR(this->results[i], this->ref[i], abs_err);
+  }
+}
+

--- a/libdistopia/test/test_utils.h
+++ b/libdistopia/test/test_utils.h
@@ -50,4 +50,6 @@ inline void EXPECT_SCALAR_NEAR(double result, double ref, float tol)
     EXPECT_NEAR(result, ref, tol);
 }
 
+
+
 #endif // DISTOPIA_TEST_UTILS_H

--- a/libdistopia/test/test_utils.h
+++ b/libdistopia/test/test_utils.h
@@ -1,0 +1,53 @@
+#ifndef DISTOPIA_TEST_UTILS_H
+#define DISTOPIA_TEST_UTILS_H
+
+#include <random>
+
+#include <gtest/gtest.h>
+// creates nrandom floating points between pos and neg limit
+template <typename T>
+void RandomFloatingPoint(T *target, const int nrandom, const int neglimit,
+                         const int poslimit)
+{
+    std::random_device rd;
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine
+    std::uniform_real_distribution<T> distribution(neglimit, poslimit);
+    for (size_t i = 0; i < nrandom; i++)
+    {
+        target[i] = distribution(gen);
+    }
+}
+
+// creates nrandom integers between pos and neg and limit
+void RandomInt(std::size_t *target, const int nrandom, const int neglimit,
+               const int poslimit)
+{
+    std::random_device rd;
+    std::mt19937 gen(rd()); // Standard mersenne_twister_engine
+    std::uniform_int_distribution<std::size_t> distribution(neglimit, poslimit);
+    for (size_t i = 0; i < nrandom; i++)
+    {
+        target[i] = distribution(gen);
+    }
+}
+
+inline void EXPECT_SCALAR_EQ(float result, float ref)
+{
+    EXPECT_FLOAT_EQ(result, ref);
+}
+
+inline void EXPECT_SCALAR_EQ(double result, double ref)
+{
+    EXPECT_DOUBLE_EQ(result, ref);
+}
+
+inline void EXPECT_SCALAR_NEAR(float result, float ref, float tol)
+{
+    EXPECT_NEAR(result, ref, tol);
+}
+inline void EXPECT_SCALAR_NEAR(double result, double ref, float tol)
+{
+    EXPECT_NEAR(result, ref, tol);
+}
+
+#endif // DISTOPIA_TEST_UTILS_H


### PR DESCRIPTION
* Adds a test executable that compares against a modified templated version of the MDAnalysis `calc_distances.h` header. 
* Fixes a bug in dihedral code where everything was coming back as `NaN`

There are some tests for triclinic code paths, but unsure if I am setting them up wrong or there is something else wrong. 